### PR TITLE
Cancel entity damage if not authenticated by authme

### DIFF
--- a/src/main/java/techcable/minecraft/combattag/listeners/CompatibilityListener.java
+++ b/src/main/java/techcable/minecraft/combattag/listeners/CompatibilityListener.java
@@ -2,9 +2,13 @@ package techcable.minecraft.combattag.listeners;
 
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.entity.Player;
 
 import techcable.minecraft.combattag.event.CombatTagByPlayerEvent;
 import techcable.minecraft.combattag.event.CombatTagEvent;
+import techcable.minecraft.combattag.Utils;
+import techcable.minecraft.combattag.PluginCompatibility;
 
 public class CompatibilityListener implements Listener {
 	@EventHandler

--- a/src/main/java/techcable/minecraft/combattag/listeners/CompatibilityListener.java
+++ b/src/main/java/techcable/minecraft/combattag/listeners/CompatibilityListener.java
@@ -21,8 +21,11 @@ public class CompatibilityListener implements Listener {
             		event.setCancelled(true);
 			return;
         	}
-        	if ((Utils.getRootDamager(event.getDamager()) != null) && (Utils.getRootDamager(event.getDamager()) instanceof Player) && !Utils.getRootDamager(event.getDamager()).isAuthenticated()) {
+        	if ((Utils.getRootDamager(event.getDamager()) != null) && 
+        		(Utils.getRootDamager(event.getDamager()) instanceof Player) && 
+        		!PluginCompatibility.isAuthenticated((Player)Utils.getRootDamager(event.getDamager()))) {
             		event.setCancelled(true);
+            		return;
         	}
      	}
 }

--- a/src/main/java/techcable/minecraft/combattag/listeners/CompatibilityListener.java
+++ b/src/main/java/techcable/minecraft/combattag/listeners/CompatibilityListener.java
@@ -15,4 +15,14 @@ public class CompatibilityListener implements Listener {
 	public void onCombatTagByPlayer(CombatTagByPlayerEvent event) {
 		if (!event.getCTAttacker().isAuthenticated()) event.setCancelled(true);
 	}
+	@EventHandler(ignoreCancelled=true)
+     	public void onDamage(EntityDamageByEntityEvent event) {
+     		if ((event.getEntity() instanceof Player) && !event.getEntity().isAuthenticated()) {
+            		event.setCancelled(true);
+			return;
+        	}
+        	if ((Utils.getRootDamager(event.getDamager()) != null) && (Utils.getRootDamager(event.getDamager()) instanceof Player) && !Utils.getRootDamager(event.getDamager()).isAuthenticated()) {
+            		event.setCancelled(true);
+        	}
+     	}
 }

--- a/src/main/java/techcable/minecraft/combattag/listeners/PlayerListener.java
+++ b/src/main/java/techcable/minecraft/combattag/listeners/PlayerListener.java
@@ -54,15 +54,6 @@ public class PlayerListener implements Listener {
     }
     @EventHandler(priority=EventPriority.MONITOR, ignoreCancelled=true)
     public void onDamage(EntityDamageByEntityEvent event) {
-        if ((event.getEntity() instanceof Player) && !event.getEntity().isAuthenticated()) {
-            event.setCancelled(true);
-            return;
-        }
-        if ((Utils.getRootDamager(event.getDamager()) != null) && (Utils.getRootDamager(event.getDamager()) instanceof Player) && !Utils.getRootDamager(event.getDamager()).isAuthenticated()) {
-            event.setCancelled(true);
-            return;
-        }
-        
     	if (!(event.getEntity() instanceof Player)) return; //Not a player
     	CombatTagPlayer defender = CombatTagPlayer.getPlayer(((Player)event.getEntity()).getUniqueId());
     	LivingEntity attacker = Utils.getRootDamager(event.getDamager());

--- a/src/main/java/techcable/minecraft/combattag/listeners/PlayerListener.java
+++ b/src/main/java/techcable/minecraft/combattag/listeners/PlayerListener.java
@@ -54,6 +54,13 @@ public class PlayerListener implements Listener {
     }
     @EventHandler(priority=EventPriority.MONITOR, ignoreCancelled=true)
     public void onDamage(EntityDamageByEntityEvent event) {
+        if ((event.getEntity() instanceof Player) && !event.getEntity().isAuthenticated()) {
+            event.setCancelled(true);
+        }
+        if ((Utils.getRootDamager(event.getDamager()) != null) && (Utils.getRootDamager(event.getDamager()) instanceof Player) && !Utils.getRootDamager(event.getDamager()).isAuthenticated()) {
+            event.setCancelled(true);
+        }
+        
     	if (!(event.getEntity() instanceof Player)) return; //Not a player
     	CombatTagPlayer defender = CombatTagPlayer.getPlayer(((Player)event.getEntity()).getUniqueId());
     	LivingEntity attacker = Utils.getRootDamager(event.getDamager());

--- a/src/main/java/techcable/minecraft/combattag/listeners/PlayerListener.java
+++ b/src/main/java/techcable/minecraft/combattag/listeners/PlayerListener.java
@@ -56,9 +56,11 @@ public class PlayerListener implements Listener {
     public void onDamage(EntityDamageByEntityEvent event) {
         if ((event.getEntity() instanceof Player) && !event.getEntity().isAuthenticated()) {
             event.setCancelled(true);
+            return;
         }
         if ((Utils.getRootDamager(event.getDamager()) != null) && (Utils.getRootDamager(event.getDamager()) instanceof Player) && !Utils.getRootDamager(event.getDamager()).isAuthenticated()) {
             event.setCancelled(true);
+            return;
         }
         
     	if (!(event.getEntity() instanceof Player)) return; //Not a player


### PR DESCRIPTION
We should cancel the damage no matter what if either of the players are not authenticated by AuthMe. An un-logged-in player cannot do damage or receive it, and should never tag or get tagged.

I should have moved the attacker variable up, and should have checked if AuthMe is available. But I didn't want to interfere with your coding style. Just trying to help a bit.
